### PR TITLE
Personal project query fix.

### DIFF
--- a/src/main/java/com/epam/ta/reportportal/database/dao/ProjectRepositoryCustomImpl.java
+++ b/src/main/java/com/epam/ta/reportportal/database/dao/ProjectRepositoryCustomImpl.java
@@ -1,20 +1,20 @@
 /*
  * Copyright 2016 EPAM Systems
- * 
- * 
+ *
+ *
  * This file is part of EPAM Report Portal.
  * https://github.com/reportportal/commons-dao
- * 
+ *
  * Report Portal is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Report Portal is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with Report Portal.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -127,8 +127,7 @@ class ProjectRepositoryCustomImpl implements ProjectRepositoryCustom {
 
 	@Override
 	public Optional<String> findPersonalProjectName(String user) {
-		Query query = Query.query(userExists(user))
-				.addCriteria(Criteria.where(PROJECT_TYPE).is(EntryType.PERSONAL))
+		Query query = Query.query(Criteria.where(PROJECT_TYPE).is(EntryType.PERSONAL))
 				.addCriteria(Criteria.where(PROJECT_ID).regex("^" + user + PERSONAL_PROJECT_POSTFIX));
 		query.fields().include("name");
 		return Optional.ofNullable(mongoTemplate.findOne(query, Project.class)).map(Project::getName);

--- a/src/test/java/com/epam/ta/reportportal/database/dao/ProjectRepositoryTest.java
+++ b/src/test/java/com/epam/ta/reportportal/database/dao/ProjectRepositoryTest.java
@@ -22,12 +22,14 @@ package com.epam.ta.reportportal.database.dao;
 
 import com.epam.ta.reportportal.BaseDaoTest;
 import com.epam.ta.reportportal.database.entity.Project;
+import com.epam.ta.reportportal.database.entity.project.EntryType;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * @author Andrei Varabyeu
@@ -50,6 +52,16 @@ public class ProjectRepositoryTest extends BaseDaoTest {
 
 		List<String> postfixes = projectRepository.findOne(projectName).getMetadata().getDemoDataPostfix();
 		Assert.assertThat("Exception during saving demo data postfix", postfixes, CoreMatchers.hasItem("metadataPostfix"));
+	}
+
+	@Test
+	public void testFindPersonalProjectByUserName() {
+		Project project = new Project();
+		project.getConfiguration().setEntryType(EntryType.PERSONAL);
+		project.setName("default_personal");
+		projectRepository.save(project);
+		Optional<String> defaultPersonal = projectRepository.findPersonalProjectName("default");
+		Assert.assertTrue(defaultPersonal.isPresent());
 	}
 
 }


### PR DESCRIPTION
Remove condition that specifies that user should be assigned onto personal project. Fixes incorrect cascade deleting of UPSA projects