### PR TITLE
Changed query for history loading to improve performance

### DIFF
--- a/src/main/java/com/epam/ta/reportportal/entity/item/TestItem.java
+++ b/src/main/java/com/epam/ta/reportportal/entity/item/TestItem.java
@@ -78,13 +78,14 @@ public class TestItem implements Serializable {
 
 	@ElementCollection(fetch = FetchType.EAGER)
 	@CollectionTable(name = "parameter", joinColumns = @JoinColumn(name = "item_id"))
+	@Fetch(FetchMode.SUBSELECT)
 	private Set<Parameter> parameters = Sets.newHashSet();
 
 	@Column(name = "unique_id", nullable = false, length = 256)
 	private String uniqueId;
 
 	@OneToMany(mappedBy = "testItem", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
-	@Fetch(FetchMode.JOIN)
+	@Fetch(FetchMode.SUBSELECT)
 	private Set<ItemAttribute> attributes = Sets.newHashSet();
 
 	@OneToMany(mappedBy = "testItem", fetch = FetchType.LAZY, orphanRemoval = true)
@@ -106,10 +107,12 @@ public class TestItem implements Serializable {
 
 	@OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
 	@JoinColumn(name = "retry_of")
+	@Fetch(FetchMode.SUBSELECT)
 	private Set<TestItem> retries = Sets.newLinkedHashSet();
 
 	@OneToMany(mappedBy = "testItem", cascade = { CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE }, fetch = FetchType.LAZY)
 	@OrderBy(value = "pattern_id")
+	@Fetch(FetchMode.SUBSELECT)
 	private Set<PatternTemplateTestItem> patternTemplateTestItems = Sets.newLinkedHashSet();
 
 	@Column(name = "has_children")

--- a/src/main/java/com/epam/ta/reportportal/entity/item/TestItemResults.java
+++ b/src/main/java/com/epam/ta/reportportal/entity/item/TestItemResults.java
@@ -21,6 +21,8 @@ import com.epam.ta.reportportal.entity.enums.StatusEnum;
 import com.epam.ta.reportportal.entity.item.issue.IssueEntity;
 import com.epam.ta.reportportal.entity.statistics.Statistics;
 import com.google.common.collect.Sets;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
 
@@ -57,6 +59,7 @@ public class TestItemResults implements Serializable {
 
 	@OneToMany
 	@JoinColumn(name = "item_id", insertable = false, updatable = false)
+	@Fetch(FetchMode.SUBSELECT)
 	private Set<Statistics> statistics = Sets.newHashSet();
 
 	@OneToOne

--- a/src/main/java/com/epam/ta/reportportal/entity/item/issue/IssueEntity.java
+++ b/src/main/java/com/epam/ta/reportportal/entity/item/issue/IssueEntity.java
@@ -19,6 +19,8 @@ package com.epam.ta.reportportal.entity.item.issue;
 import com.epam.ta.reportportal.entity.bts.Ticket;
 import com.epam.ta.reportportal.entity.item.TestItemResults;
 import com.google.common.collect.Sets;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 
 import javax.persistence.*;
 import java.io.Serializable;
@@ -56,6 +58,7 @@ public class IssueEntity implements Serializable {
 
 	@ManyToMany(cascade = { CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH }, fetch = FetchType.EAGER)
 	@JoinTable(name = "issue_ticket", joinColumns = @JoinColumn(name = "issue_id"), inverseJoinColumns = @JoinColumn(name = "ticket_id"))
+	@Fetch(FetchMode.SUBSELECT)
 	private Set<Ticket> tickets = Sets.newHashSet();
 
 	public IssueEntity() {

--- a/src/test/java/com/epam/ta/reportportal/dao/TestItemRepositoryTest.java
+++ b/src/test/java/com/epam/ta/reportportal/dao/TestItemRepositoryTest.java
@@ -127,10 +127,19 @@ class TestItemRepositoryTest extends BaseTest {
 
 	@Test
 	void testLoadItemsHistory() {
+		//GIVEN
 		final String uniqueId = "unqIdSTEP7";
 
-		List<TestItem> items = testItemRepository.loadItemsHistory(Lists.newArrayList(uniqueId), Lists.newArrayList(7L, 8L, 9L));
-		assertEquals(7, items.size(), "Incorrect items size");
+		List<String> uniqueIds = Lists.newArrayList(uniqueId);
+		ArrayList<Long> launchesIds = Lists.newArrayList(7L, 8L, 9L);
+
+		int limit = 6;
+
+		//WHEN
+		List<TestItem> items = testItemRepository.loadItemsHistory(uniqueIds, launchesIds, limit);
+
+		//THEN
+		assertEquals(limit, items.size(), String.format("Items size should be %d", limit));
 		items.forEach(it -> assertTrue(
 				it.getUniqueId().equals(uniqueId) && (it.getLaunchId() == 7L || it.getLaunchId() == 8L || it.getLaunchId() == 9L)));
 	}


### PR DESCRIPTION
The root cause of low performance was in big number of queries:
- 10000 items with identical unique ids were queried
- Every item has several related entities and collections
- For every of 10000 items additional query was generated for every related entity and collection
- It  was approximately 10001 * (number of eager relations and their subrelations in every query)  queries

To prevent generation of additional queries for related entities and collections the following steps were done:
- Now one-to-one light entities are joined in main query. Collections are not joined this way because large collections in left join can cause extremely slow query execution and application can even get frozen.
- FetchMode.SUBSELECT is used to fetch collections that can be large. This fetch mode assumes that after main query execution a query for every collection for all found items is generated. 
In more detail, it will be in this order:
Get test items
Get parameters for all the items
Get attributes for all the items
Get pattern templates for all the items
Get retries for all the items
etc.

Now it takes ~3-4s for getItemsHistory rest service to complete for light (without any data in related entities and collections) 10000 items with identical unique ids.
If number of related entities and collections starts to grow then execution time increases up to 10s. Initial performance test by QA team was done on relatively light entities where quite small related collections were used.
If items have large collections and all of them are filled then execution time increases up to 20s.