### PR TITLE
#1196 Add `datastore.minio.bucketPrefix` and `datastore.minio.defaultBucketName` configuration properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# Unreleased
+
+### New Features
+* Added `datastore.minio.bucketPrefix` and `datastore.minio.defaultBucketName` configuration properties
+
 ## 3.2.1
 ##### Released: XXX 2017
 

--- a/src/main/java/com/epam/ta/reportportal/config/DataStoreConfiguration.java
+++ b/src/main/java/com/epam/ta/reportportal/config/DataStoreConfiguration.java
@@ -54,8 +54,10 @@ public class DataStoreConfiguration {
 
 	@Bean
 	@ConditionalOnProperty(name = "datastore.type", havingValue = "minio")
-	public DataStore minioDataStore(@Autowired MinioClient minioClient) {
-		return new MinioDataStore(minioClient);
+	public DataStore minioDataStore(@Autowired MinioClient minioClient,
+			@Value("${datastore.minio.bucketPrefix}") String bucketPrefix,
+			@Value("${datastore.minio.defaultBucketName}") String defaultBucketName) {
+		return new MinioDataStore(minioClient, bucketPrefix, defaultBucketName);
 	}
 
 	@Bean("attachmentThumbnailator")

--- a/src/main/java/com/epam/ta/reportportal/filesystem/distributed/minio/MinioDataStore.java
+++ b/src/main/java/com/epam/ta/reportportal/filesystem/distributed/minio/MinioDataStore.java
@@ -40,16 +40,17 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 public class MinioDataStore implements DataStore {
 
-	public static final String BUCKET_PREFIX = "prj-";
-	public static final String DEFAULT_BUCKET = "rp-bucket";
-
 	private static final Logger LOGGER = LoggerFactory.getLogger(MinioDataStore.class);
 	private static final Lock CREATE_BUCKET_LOCK = new ReentrantLock();
 
 	private final MinioClient minioClient;
+	private final String bucketPrefix;
+	private final String defaultBucketName;
 
-	public MinioDataStore(MinioClient minioClient) {
+	public MinioDataStore(MinioClient minioClient, String bucketPrefix, String defaultBucketName) {
 		this.minioClient = minioClient;
+		this.bucketPrefix = bucketPrefix;
+		this.defaultBucketName = defaultBucketName;
 	}
 
 	@Override
@@ -101,9 +102,9 @@ public class MinioDataStore implements DataStore {
 		Path targetPath = Paths.get(filePath);
 		int nameCount = targetPath.getNameCount();
 		if (nameCount > 1) {
-			return new MinioFile(BUCKET_PREFIX + retrievePath(targetPath, 0, 1), retrievePath(targetPath, 1, nameCount));
+			return new MinioFile(bucketPrefix + retrievePath(targetPath, 0, 1), retrievePath(targetPath, 1, nameCount));
 		} else {
-			return new MinioFile(DEFAULT_BUCKET, retrievePath(targetPath, 0, 1));
+			return new MinioFile(defaultBucketName, retrievePath(targetPath, 0, 1));
 		}
 
 	}

--- a/src/test/java/com/epam/ta/reportportal/filesystem/distributed/minio/MinioDataStoreTest.java
+++ b/src/test/java/com/epam/ta/reportportal/filesystem/distributed/minio/MinioDataStoreTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
 
-import static com.epam.ta.reportportal.filesystem.distributed.minio.MinioDataStore.DEFAULT_BUCKET;
 import static org.mockito.Mockito.*;
 
 /**
@@ -32,11 +31,13 @@ import static org.mockito.Mockito.*;
 class MinioDataStoreTest {
 
 	private static final String FILE_PATH = "someFile";
+	private static final String BUCKET_PREFIX = "prj-";
+	private static final String DEFAULT_BUCKET_NAME = "rp-bucket";
 
 	private final MinioClient minioClient = mock(MinioClient.class);
 	private final InputStream inputStream = mock(InputStream.class);
 
-	private final MinioDataStore minioDataStore = new MinioDataStore(minioClient);
+	private final MinioDataStore minioDataStore = new MinioDataStore(minioClient, BUCKET_PREFIX, DEFAULT_BUCKET_NAME);
 
 	@Test
 	void save() throws Exception {
@@ -46,13 +47,13 @@ class MinioDataStoreTest {
 
 		minioDataStore.save(FILE_PATH, inputStream);
 
-		verify(minioClient, times(1)).putObject(DEFAULT_BUCKET, FILE_PATH, inputStream, inputStream.available(), Maps.newHashMap());
+		verify(minioClient, times(1)).putObject(DEFAULT_BUCKET_NAME, FILE_PATH, inputStream, inputStream.available(), Maps.newHashMap());
 	}
 
 	@Test
 	void load() throws Exception {
 
-		when(minioClient.getObject(DEFAULT_BUCKET, FILE_PATH)).thenReturn(inputStream);
+		when(minioClient.getObject(DEFAULT_BUCKET_NAME, FILE_PATH)).thenReturn(inputStream);
 		InputStream loaded = minioDataStore.load(FILE_PATH);
 
 		Assertions.assertEquals(inputStream, loaded);
@@ -63,6 +64,6 @@ class MinioDataStoreTest {
 
 		minioDataStore.delete(FILE_PATH);
 
-		verify(minioClient, times(1)).removeObject(DEFAULT_BUCKET, FILE_PATH);
+		verify(minioClient, times(1)).removeObject(DEFAULT_BUCKET_NAME, FILE_PATH);
 	}
 }


### PR DESCRIPTION
Originally bucket name was hardcoded with a constant, but S3 bucket names are global throughout AWS, so it caused impossibility to install plugins in RP deployed to AWS

Allows to fix https://github.com/reportportal/service-api/issues/1196 and https://github.com/reportportal/kubernetes/issues/115