### PR TITLE
EPMRPP-87044 exclude empty statistics records from processing

### DIFF
--- a/src/main/java/com/epam/ta/reportportal/dao/widget/healthcheck/content/HealthCheckTableChain.java
+++ b/src/main/java/com/epam/ta/reportportal/dao/widget/healthcheck/content/HealthCheckTableChain.java
@@ -70,14 +70,14 @@ public class HealthCheckTableChain implements
         result.add(resultEntry);
       });
     } else {
-      columnMapping.forEach((key, attributes) -> {
-        HealthCheckTableContent resultEntry = ofNullable(content.remove(key)).map(
-            statisticsContent -> entryFromStatistics(key,
-                statisticsContent
-            )).orElseGet(HealthCheckTableContent::new);
-        resultEntry.setCustomValues(attributes);
-        result.add(resultEntry);
-      });
+      columnMapping.forEach((key, attributes) ->
+          ofNullable(content.remove(key))
+              .map(statisticsContent -> entryFromStatistics(key, statisticsContent))
+              .ifPresent(resultEntry -> {
+                resultEntry.setCustomValues(attributes);
+                result.add(resultEntry);
+              }));
+
       content.forEach((key, statistics) -> result.add(entryFromStatistics(key, statistics)));
     }
     return result;

--- a/src/test/java/com/epam/ta/reportportal/dao/WidgetContentRepositoryTest.java
+++ b/src/test/java/com/epam/ta/reportportal/dao/WidgetContentRepositoryTest.java
@@ -1337,7 +1337,7 @@ class WidgetContentRepositoryTest extends BaseTest {
             .of("first", "build", Sort.by(Sort.Direction.DESC, "customColumn"), true,
                 new ArrayList<>()));
 
-    assertFalse(healthCheckTableContents.isEmpty());
+    assertTrue(healthCheckTableContents.isEmpty());
 
     initParams = HealthCheckTableInitParams.of("hello",
         com.google.common.collect.Lists.newArrayList("build"));
@@ -1440,7 +1440,7 @@ class WidgetContentRepositoryTest extends BaseTest {
             new ArrayList<>()
         ));
 
-    assertFalse(healthCheckTableContents.isEmpty());
+    assertTrue(healthCheckTableContents.isEmpty());
 
     widgetContentRepository.removeWidgetView(initParams.getViewName());
 


### PR DESCRIPTION
The root cause: 
https://github.com/reportportal/service-api/blob/dbfa74d83f85133cd6a4e84740749f2b98cdc274/src/main/java/com/epam/ta/reportportal/core/widget/content/loader/materialized/HealthCheckTableReadyContentLoader.java#L83
groupingBy collector fails when operating with null values