### PR TITLE
Membership for org group projects

### DIFF
--- a/src/main/java/com/epam/ta/reportportal/dao/GroupMembershipRepository.java
+++ b/src/main/java/com/epam/ta/reportportal/dao/GroupMembershipRepository.java
@@ -177,8 +177,34 @@ public interface GroupMembershipRepository extends
       JOIN groups_users gu
         ON gp.group_id = gu.group_id
       WHERE gu.user_id = :user_id
+      ORDER BY gp.project_id
       """,
       nativeQuery = true
   )
   List<GroupProject> findAllUserProjects(@Param("user_id") Long userId);
+
+  /**
+   * Finds all projects of the user via group membership in the organization.
+   *
+   * @param userId user id
+   * @param orgId organization id
+   * @return {@link List} of {@link GroupProject}
+   */
+  @Query(value = """
+      SELECT gp.project_id, gp.group_id, gp.project_role, gp.created_at, gp.updated_at
+      FROM groups_projects gp
+      JOIN groups_users gu
+        ON gp.group_id = gu.group_id
+      JOIN groups g
+        ON g.id = gp.group_id
+      WHERE gu.user_id = :userId
+        AND g.org_id = :orgId
+      ORDER BY gp.project_id
+      """,
+      nativeQuery = true
+  )
+  List<GroupProject> findAllUserProjectsInOrganization(
+      @Param("userId") Long userId,
+      @Param("orgId") Long orgId
+  );
 }

--- a/src/test/java/com/epam/ta/reportportal/dao/GroupMembershipRepositoryTest.java
+++ b/src/test/java/com/epam/ta/reportportal/dao/GroupMembershipRepositoryTest.java
@@ -145,4 +145,13 @@ class GroupMembershipRepositoryTest extends BaseTest {
         fakeChubaka.getId());
     assertEquals(4, groupProjects.size());
   }
+
+  @Test
+  void ShouldReturnAllUserProjectsInOrganization() {
+    var groupProjects = groupMembershipRepository.findAllUserProjectsInOrganization(
+        fakeChubaka.getId(),
+        1L
+    );
+    assertEquals(4, groupProjects.size());
+  }
 }

--- a/src/test/resources/db/migration/V001008__test_group_init.sql
+++ b/src/test/resources/db/migration/V001008__test_group_init.sql
@@ -19,24 +19,24 @@ BEGIN
     chubaka := (SELECT u.id FROM users u WHERE login = 'chubaka');
     fake_chubaka := (SELECT u.id FROM users u WHERE login = 'fake_chubaka');
 
-    INSERT INTO groups (name, slug, created_by, created_at, uuid)
-    VALUES ('Rebel army', 'rebel-group', 1, now(), gen_random_uuid());
+    INSERT INTO groups (name, slug, created_by, created_at, uuid, org_id)
+    VALUES ('Rebel army', 'rebel-group', 1, now(), gen_random_uuid(), 1);
     rebel := (SELECT currval(pg_get_serial_sequence('groups', 'id')));
 
-    INSERT INTO groups (name, slug, created_by, created_at, uuid)
-    VALUES ('Ewoks group', 'ewoks-group', 1, now(), gen_random_uuid());
+    INSERT INTO groups (name, slug, created_by, created_at, uuid, org_id)
+    VALUES ('Ewoks group', 'ewoks-group', 1, now(), gen_random_uuid(), 1);
     ewoks := (SELECT currval(pg_get_serial_sequence('groups', 'id')));
 
-    INSERT INTO groups (name, slug, created_by, created_at, uuid)
-    VALUES ('Empire group', 'empire-group', 1, now(), gen_random_uuid());
+    INSERT INTO groups (name, slug, created_by, created_at, uuid, org_id)
+    VALUES ('Empire group', 'empire-group', 1, now(), gen_random_uuid(), 1);
     empire := (SELECT currval(pg_get_serial_sequence('groups', 'id')));
 
-    INSERT INTO groups (name, slug, created_by, created_at, uuid)
-    VALUES ('Jedi group', 'jedi-group', 1, now(), gen_random_uuid());
+    INSERT INTO groups (name, slug, created_by, created_at, uuid, org_id)
+    VALUES ('Jedi group', 'jedi-group', 1, now(), gen_random_uuid(), 1);
     jedi := (SELECT currval(pg_get_serial_sequence('groups', 'id')));
 
-    INSERT INTO groups (name, slug, created_by, created_at, uuid)
-    VALUES ('Sith order group', 'sith-group', 1, now(), gen_random_uuid());
+    INSERT INTO groups (name, slug, created_by, created_at, uuid, org_id)
+    VALUES ('Sith order group', 'sith-group', 1, now(), gen_random_uuid(), 1);
     sith_order := (SELECT currval(pg_get_serial_sequence('groups', 'id')));
 
     INSERT INTO groups_users (group_id, user_id, created_at)


### PR DESCRIPTION
This pull request enhances the functionality of the `GroupMembershipRepository` by adding a method to fetch user projects within a specific organization and updates the corresponding test and database migration files to support this feature.

### Repository Enhancements:
* Added `findAllUserProjectsInOrganization` method to `GroupMembershipRepository` to retrieve user projects filtered by organization ID. The method includes an SQL query with an `ORDER BY` clause for consistent results.

### Test Updates:
* Added a new test case, `ShouldReturnAllUserProjectsInOrganization`, in `GroupMembershipRepositoryTest` to verify the functionality of the newly added repository method.

### Database Migration:
* Updated `V001008__test_group_init.sql` to include an `org_id` column in the `groups` table and populated it with a default value for existing test data. This ensures compatibility with the new repository method.