### PR TITLE
Add group filter by orgId

### DIFF
--- a/src/main/java/com/epam/ta/reportportal/dao/GroupRepository.java
+++ b/src/main/java/com/epam/ta/reportportal/dao/GroupRepository.java
@@ -24,6 +24,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /**
  * Repository for {@link Group}.
@@ -59,6 +60,16 @@ public interface GroupRepository extends ReportPortalRepository<Group, Long> {
   @EntityGraph(attributePaths = {"users", "projects"})
   @Query("SELECT g FROM Group g")
   Page<Group> findAllWithUsersAndProjects(Pageable pageable);
+
+  /**
+   * Retrieves all groups with their users and projects with pagination.
+   *
+   * @param pageable {@link Pageable} object
+   * @return {@link Page} of {@link Group}
+   */
+  @EntityGraph(attributePaths = {"users", "projects"})
+  @Query("SELECT g FROM Group g WHERE g.organizationId = :orgId")
+  Page<Group> findAllWithUsersAndProjects(Pageable pageable, @Param("orgId") Long orgId);
 
   /**
    * Retrieves a group by its ID with users and projects.

--- a/src/main/java/com/epam/ta/reportportal/dao/GroupRepository.java
+++ b/src/main/java/com/epam/ta/reportportal/dao/GroupRepository.java
@@ -65,11 +65,12 @@ public interface GroupRepository extends ReportPortalRepository<Group, Long> {
    * Retrieves all groups with their users and projects with pagination.
    *
    * @param pageable {@link Pageable} object
+   * @param orgId Organization identifier
    * @return {@link Page} of {@link Group}
    */
   @EntityGraph(attributePaths = {"users", "projects"})
   @Query("SELECT g FROM Group g WHERE g.organizationId = :orgId")
-  Page<Group> findAllWithUsersAndProjects(Pageable pageable, @Param("orgId") Long orgId);
+  Page<Group> findAllWithUsersAndProjects(@Param("orgId") Long orgId, Pageable pageable);
 
   /**
    * Retrieves a group by its ID with users and projects.

--- a/src/test/java/com/epam/ta/reportportal/dao/GroupProjectRepositoryTest.java
+++ b/src/test/java/com/epam/ta/reportportal/dao/GroupProjectRepositoryTest.java
@@ -90,8 +90,8 @@ class GroupProjectRepositoryTest extends BaseTest {
     );
     groupProjectsPage.forEach(g ->
         {
-          Hibernate.initialize(g.getGroup());
-          Hibernate.initialize(g.getGroup().getUsers());
+          Hibernate.initialize(g.getGroup().getSlug());
+          Hibernate.initialize(g.getGroup().getUsers().size());
         }
     );
 

--- a/src/test/java/com/epam/ta/reportportal/dao/GroupProjectRepositoryTest.java
+++ b/src/test/java/com/epam/ta/reportportal/dao/GroupProjectRepositoryTest.java
@@ -24,6 +24,8 @@ import com.epam.ta.reportportal.entity.group.Group;
 import com.epam.ta.reportportal.entity.group.GroupProject;
 import jakarta.persistence.EntityManager;
 import java.util.List;
+
+import org.hibernate.Hibernate;
 import org.hibernate.Session;
 import org.hibernate.stat.Statistics;
 import org.junit.jupiter.api.BeforeEach;
@@ -65,15 +67,17 @@ class GroupProjectRepositoryTest extends BaseTest {
 
   @Test
   void testFindAllGroupProjects() {
-    List<GroupProject> groupProjects = groupProjectRepository.findAllByGroupId(rebel.getId());
+    List<GroupProject> groupProjects =
+        groupProjectRepository.findAllByGroupId(rebel.getId());
     assertEquals(1, groupProjects.size());
   }
 
   @Test
   void testFindProjectsPageByGroupId() {
     var pageable = PageRequest.of(0, 10);
-    Page<GroupProject> groupProjects = groupProjectRepository.findAllByGroupId(rebel.getId(),
-        pageable);
+    Page<GroupProject> groupProjects =
+        groupProjectRepository.findAllByGroupId(rebel.getId(),
+            pageable);
     assertNotNull(groupProjects);
     assertEquals(1, groupProjects.getTotalElements());
   }
@@ -86,8 +90,8 @@ class GroupProjectRepositoryTest extends BaseTest {
     );
     groupProjectsPage.forEach(g ->
         {
-          System.out.println("Group slug: " + g.getGroup().getSlug());
-          System.out.println("Group users count: " + g.getGroup().getUsers().size());
+          Hibernate.initialize(g.getGroup());
+          Hibernate.initialize(g.getGroup().getUsers());
         }
     );
 
@@ -104,8 +108,8 @@ class GroupProjectRepositoryTest extends BaseTest {
     ).orElseThrow(
         () -> new RuntimeException("Group project not found")
     );
-    System.out.println("Group slug: " + group.getGroup().getSlug());
-    System.out.println("Group users count: " + group.getGroup().getUsers().size());
+    Hibernate.initialize(group.getGroup().getSlug());
+    Hibernate.initialize(group.getGroup().getUsers().size());
 
     assertEquals(1, statistics.getQueryExecutionCount());
     assertEquals(1, statistics.getPrepareStatementCount());

--- a/src/test/java/com/epam/ta/reportportal/dao/GroupRepositoryTest.java
+++ b/src/test/java/com/epam/ta/reportportal/dao/GroupRepositoryTest.java
@@ -89,6 +89,20 @@ public class GroupRepositoryTest extends BaseTest {
   }
 
   @Test
+  void testFindAllWithUsersAndProjectsFilteredByOrgId() {
+    var groups = groupRepository.findAllWithUsersAndProjects(null, 1L);
+    assertEquals(5, groups.getContent().size());
+
+    groups.forEach(group -> {
+      System.out.println("Group users: " + group.getUsers().size());
+      System.out.println("Group projects: " + group.getProjects().size());
+    });
+
+    assertEquals(1, statistics.getQueryExecutionCount());
+    assertEquals(1, statistics.getPrepareStatementCount());
+  }
+
+  @Test
   void testFindByIdWithUsersAndProjects() {
     var group = groupRepository.findByIdWithUsersAndProjects(rebelGroup.getId())
         .orElseThrow(() -> new RuntimeException("Group not found")

--- a/src/test/java/com/epam/ta/reportportal/dao/GroupRepositoryTest.java
+++ b/src/test/java/com/epam/ta/reportportal/dao/GroupRepositoryTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.epam.ta.reportportal.BaseTest;
 import com.epam.ta.reportportal.entity.group.Group;
 import jakarta.persistence.EntityManager;
+import org.hibernate.Hibernate;
 import org.hibernate.Session;
 import org.hibernate.stat.Statistics;
 import org.junit.jupiter.api.BeforeEach;
@@ -80,8 +81,8 @@ public class GroupRepositoryTest extends BaseTest {
     assertEquals(5, groups.getContent().size());
 
     groups.forEach(group -> {
-      System.out.println("Group users: " + group.getUsers().size());
-      System.out.println("Group projects: " + group.getProjects().size());
+      Hibernate.initialize(group.getUsers().size());
+      Hibernate.initialize(group.getProjects().size());
     });
 
     assertEquals(1, statistics.getQueryExecutionCount());
@@ -94,8 +95,8 @@ public class GroupRepositoryTest extends BaseTest {
     assertEquals(5, groups.getContent().size());
 
     groups.forEach(group -> {
-      System.out.println("Group users: " + group.getUsers().size());
-      System.out.println("Group projects: " + group.getProjects().size());
+      Hibernate.initialize(group.getUsers().size());
+      Hibernate.initialize(group.getProjects().size());
     });
 
     assertEquals(1, statistics.getQueryExecutionCount());
@@ -108,8 +109,8 @@ public class GroupRepositoryTest extends BaseTest {
         .orElseThrow(() -> new RuntimeException("Group not found")
         );
 
-    System.out.println("Group users: " + group.getUsers().size());
-    System.out.println("Group projects: " + group.getProjects().size());
+    Hibernate.initialize(group.getUsers().size());
+    Hibernate.initialize(group.getProjects().size());
 
     assertEquals(1, statistics.getQueryExecutionCount());
     assertEquals(1, statistics.getPrepareStatementCount());

--- a/src/test/java/com/epam/ta/reportportal/dao/GroupRepositoryTest.java
+++ b/src/test/java/com/epam/ta/reportportal/dao/GroupRepositoryTest.java
@@ -90,7 +90,7 @@ public class GroupRepositoryTest extends BaseTest {
 
   @Test
   void testFindAllWithUsersAndProjectsFilteredByOrgId() {
-    var groups = groupRepository.findAllWithUsersAndProjects(null, 1L);
+    var groups = groupRepository.findAllWithUsersAndProjects(1L, null);
     assertEquals(5, groups.getContent().size());
 
     groups.forEach(group -> {

--- a/src/test/java/com/epam/ta/reportportal/dao/ItemAttributeRepositoryTest.java
+++ b/src/test/java/com/epam/ta/reportportal/dao/ItemAttributeRepositoryTest.java
@@ -49,10 +49,13 @@ class ItemAttributeRepositoryTest extends BaseTest {
 
     Filter filter = Filter.builder()
         .withTarget(Launch.class)
-        .withCondition(FilterCondition.builder().eq(CRITERIA_PROJECT_ID, "1").build())
+        .withCondition(
+            FilterCondition.builder().eq(CRITERIA_PROJECT_ID, "1").build())
         .build();
-    List<String> keys = repository.findAllKeysByLaunchFilter(filter, PageRequest.of(0, 600), false,
-        "step", false);
+    List<String> keys =
+        repository.findAllKeysByLaunchFilter(filter, PageRequest.of(0, 600),
+            false,
+            "step", false);
 
     assertFalse(keys.isEmpty());
   }
@@ -62,10 +65,12 @@ class ItemAttributeRepositoryTest extends BaseTest {
     final String launchKeyName = "key1";
     final Long launchId = 1L;
 
-    final Optional<ItemAttribute> optionalAttr = repository.findByLaunchIdAndKeyAndSystem(launchId,
-        launchKeyName, false);
+    final Optional<ItemAttribute> optionalAttr =
+        repository.findByLaunchIdAndKeyAndSystem(launchId,
+            launchKeyName, false);
     assertTrue(optionalAttr.isPresent(), "Should be present");
-    assertEquals(launchId, optionalAttr.get().getLaunch().getId(), "Unexpected launch id");
+    assertEquals(launchId, optionalAttr.get().getLaunch().getId(),
+        "Unexpected launch id");
     assertEquals(launchKeyName, optionalAttr.get().getKey(), "Unexpected key");
   }
 
@@ -75,12 +80,13 @@ class ItemAttributeRepositoryTest extends BaseTest {
     final String stepKey = "step";
     final String partOfItemValue = "val";
 
-    final List<String> values = repository.findTestItemAttributeValues(launchId, stepKey,
-        partOfItemValue, false);
-    System.out.println();
+    final List<String> values =
+        repository.findTestItemAttributeValues(launchId, stepKey,
+            partOfItemValue, false);
     assertNotNull(values, "Should not be null");
-    assertTrue(!values.isEmpty(), "Should not be empty");
-    values.forEach(it -> assertTrue(it.contains(partOfItemValue), "Value not matches"));
+    assertFalse(values.isEmpty(), "Should not be empty");
+    values.forEach(
+        it -> assertTrue(it.contains(partOfItemValue), "Value not matches"));
   }
 
   @Test
@@ -89,11 +95,13 @@ class ItemAttributeRepositoryTest extends BaseTest {
     final String launchName = "name 1";
     final String partOfItemKey = "st";
 
-    final List<String> keys = repository.findTestItemKeysByProjectIdAndLaunchName(projectId,
-        launchName, partOfItemKey, false);
+    final List<String> keys =
+        repository.findTestItemKeysByProjectIdAndLaunchName(projectId,
+            launchName, partOfItemKey, false);
     assertNotNull(keys, "Should not be null");
-    assertTrue(!keys.isEmpty(), "Should not be empty");
-    keys.forEach(it -> assertTrue(it.contains(partOfItemKey), "Key not matches"));
+    assertFalse(keys.isEmpty(), "Should not be empty");
+    keys.forEach(
+        it -> assertTrue(it.contains(partOfItemKey), "Key not matches"));
   }
 
   @Test
@@ -103,11 +111,13 @@ class ItemAttributeRepositoryTest extends BaseTest {
     final String stepKey = "step";
     final String partOfItemValue = "val";
 
-    final List<String> values = repository.findTestItemValuesByProjectIdAndLaunchName(projectId,
-        launchName, stepKey, partOfItemValue, false);
+    final List<String> values =
+        repository.findTestItemValuesByProjectIdAndLaunchName(projectId,
+            launchName, stepKey, partOfItemValue, false);
     assertNotNull(values, "Should not be null");
-    assertTrue(!values.isEmpty(), "Should not be empty");
-    values.forEach(it -> assertTrue(it.contains(partOfItemValue), "Value not matches"));
+    assertFalse(values.isEmpty(), "Should not be empty");
+    values.forEach(
+        it -> assertTrue(it.contains(partOfItemValue), "Value not matches"));
   }
 
   @Test
@@ -115,11 +125,13 @@ class ItemAttributeRepositoryTest extends BaseTest {
     final Long projectId = 1L;
     final String valuePart = "val";
 
-    final List<String> values = repository.findUniqueAttributeValuesByPart(projectId, null,
-        valuePart, null, false);
+    final List<String> values =
+        repository.findUniqueAttributeValuesByPart(projectId, null,
+            valuePart, null, false);
     assertNotNull(values, "Should not be null");
-    assertTrue(!values.isEmpty(), "Should not be empty");
-    values.forEach(it -> assertTrue(it.contains(valuePart), "Value not matches"));
+    assertFalse(values.isEmpty(), "Should not be empty");
+    values.forEach(
+        it -> assertTrue(it.contains(valuePart), "Value not matches"));
   }
 
   @Test
@@ -128,10 +140,11 @@ class ItemAttributeRepositoryTest extends BaseTest {
     var launchId = 1L;
     var keyPart = "st";
 
-    final List<String> keys = repository.findUniqueAttributeKeysByPart(projectId, keyPart, launchId,
-        false);
+    final List<String> keys =
+        repository.findUniqueAttributeKeysByPart(projectId, keyPart, launchId,
+            false);
     assertNotNull(keys, "Should not be null");
-    assertTrue(!keys.isEmpty(), "Should not be empty");
+    assertFalse(keys.isEmpty(), "Should not be empty");
     keys.forEach(it -> assertTrue(it.contains(keyPart), "Key not matches"));
   }
 
@@ -140,10 +153,12 @@ class ItemAttributeRepositoryTest extends BaseTest {
     final Long projectId = 1L;
     final String partOfLaunchKey = "ke";
 
-    final List<String> keys = repository.findLaunchAttributeKeys(projectId, partOfLaunchKey, false);
+    final List<String> keys =
+        repository.findLaunchAttributeKeys(projectId, partOfLaunchKey, false);
     assertNotNull(keys, "Should not be null");
-    assertTrue(!keys.isEmpty(), "Should not be empty");
-    keys.forEach(it -> assertTrue(it.contains(partOfLaunchKey), "Key not matches"));
+    assertFalse(keys.isEmpty(), "Should not be empty");
+    keys.forEach(
+        it -> assertTrue(it.contains(partOfLaunchKey), "Key not matches"));
   }
 
   @Test
@@ -152,11 +167,13 @@ class ItemAttributeRepositoryTest extends BaseTest {
     final String launchKeyName = "key1";
     final String partOfItemValue = "val";
 
-    final List<String> values = repository.findLaunchAttributeValues(projectId, launchKeyName,
-        partOfItemValue, false);
+    final List<String> values =
+        repository.findLaunchAttributeValues(projectId, launchKeyName,
+            partOfItemValue, false);
     assertNotNull(values, "Should not be null");
-    assertTrue(!values.isEmpty(), "Should not be empty");
-    values.forEach(it -> assertTrue(it.contains(partOfItemValue), "Value not matches"));
+    assertFalse(values.isEmpty(), "Should not be empty");
+    values.forEach(
+        it -> assertTrue(it.contains(partOfItemValue), "Value not matches"));
   }
 
   @Test
@@ -165,11 +182,13 @@ class ItemAttributeRepositoryTest extends BaseTest {
 
     Assertions.assertEquals(1, result);
 
-    List<String> attributeKeys = repository.findUniqueAttributeKeysByPart(1L, "new", 1L, false);
+    List<String> attributeKeys =
+        repository.findUniqueAttributeKeysByPart(1L, "new", 1L, false);
 
     Assertions.assertNotNull(attributeKeys);
     Assertions.assertFalse(attributeKeys.isEmpty());
-    Assertions.assertTrue(attributeKeys.stream().anyMatch(k -> k.equals("new key")));
+    Assertions.assertTrue(
+        attributeKeys.stream().anyMatch(k -> k.equals("new key")));
   }
 
   @Test
@@ -178,8 +197,9 @@ class ItemAttributeRepositoryTest extends BaseTest {
 
     Assertions.assertEquals(1, result);
 
-    final Optional<ItemAttribute> attribute = repository.findByLaunchIdAndKeyAndSystem(1L, "new",
-        false);
+    final Optional<ItemAttribute> attribute =
+        repository.findByLaunchIdAndKeyAndSystem(1L, "new",
+            false);
 
     Assertions.assertTrue(attribute.isPresent());
     Assertions.assertEquals("new", attribute.get().getKey());
@@ -192,10 +212,12 @@ class ItemAttributeRepositoryTest extends BaseTest {
     repository.saveByLaunchId(1L, "first", "first", true);
     repository.saveByLaunchId(1L, "second", "second", false);
 
-    final Optional<ItemAttribute> first = repository.findByLaunchIdAndKeyAndSystem(1L, "first",
-        true);
-    final Optional<ItemAttribute> second = repository.findByLaunchIdAndKeyAndSystem(1L, "second",
-        false);
+    final Optional<ItemAttribute> first =
+        repository.findByLaunchIdAndKeyAndSystem(1L, "first",
+            true);
+    final Optional<ItemAttribute> second =
+        repository.findByLaunchIdAndKeyAndSystem(1L, "second",
+            false);
 
     Assertions.assertTrue(first.isPresent());
     Assertions.assertTrue(second.isPresent());
@@ -203,10 +225,12 @@ class ItemAttributeRepositoryTest extends BaseTest {
     repository.deleteAllByLaunchIdAndKeyAndSystem(1L, "first", true);
     repository.deleteAllByLaunchIdAndKeyAndSystem(1L, "second", false);
 
-    final Optional<ItemAttribute> firstAfterRemove = repository.findByLaunchIdAndKeyAndSystem(1L,
-        "first", true);
-    final Optional<ItemAttribute> secondAfterRemove = repository.findByLaunchIdAndKeyAndSystem(1L,
-        "second", false);
+    final Optional<ItemAttribute> firstAfterRemove =
+        repository.findByLaunchIdAndKeyAndSystem(1L,
+            "first", true);
+    final Optional<ItemAttribute> secondAfterRemove =
+        repository.findByLaunchIdAndKeyAndSystem(1L,
+            "second", false);
 
     Assertions.assertFalse(firstAfterRemove.isPresent());
     Assertions.assertFalse(secondAfterRemove.isPresent());

--- a/src/test/resources/db/migration/V001008__test_group_init.sql
+++ b/src/test/resources/db/migration/V001008__test_group_init.sql
@@ -19,24 +19,24 @@ BEGIN
     chubaka := (SELECT u.id FROM users u WHERE login = 'chubaka');
     fake_chubaka := (SELECT u.id FROM users u WHERE login = 'fake_chubaka');
 
-    INSERT INTO groups (name, slug, created_by, created_at, uuid)
-    VALUES ('Rebel army', 'rebel-group', 1, now(), gen_random_uuid());
+    INSERT INTO groups (name, slug, created_by, created_at, uuid, org_id)
+    VALUES ('Rebel army', 'rebel-group', 1, now(), gen_random_uuid(), 1);
     rebel := (SELECT currval(pg_get_serial_sequence('groups', 'id')));
 
-    INSERT INTO groups (name, slug, created_by, created_at, uuid)
-    VALUES ('Ewoks group', 'ewoks-group', 1, now(), gen_random_uuid());
+    INSERT INTO groups (name, slug, created_by, created_at, uuid, org_id)
+    VALUES ('Ewoks group', 'ewoks-group', 1, now(), gen_random_uuid(), 1);
     ewoks := (SELECT currval(pg_get_serial_sequence('groups', 'id')));
 
-    INSERT INTO groups (name, slug, created_by, created_at, uuid)
-    VALUES ('Empire group', 'empire-group', 1, now(), gen_random_uuid());
+    INSERT INTO groups (name, slug, created_by, created_at, uuid, org_id)
+    VALUES ('Empire group', 'empire-group', 1, now(), gen_random_uuid(), 1);
     empire := (SELECT currval(pg_get_serial_sequence('groups', 'id')));
 
-    INSERT INTO groups (name, slug, created_by, created_at, uuid)
-    VALUES ('Jedi group', 'jedi-group', 1, now(), gen_random_uuid());
+    INSERT INTO groups (name, slug, created_by, created_at, uuid, org_id)
+    VALUES ('Jedi group', 'jedi-group', 1, now(), gen_random_uuid(), 1);
     jedi := (SELECT currval(pg_get_serial_sequence('groups', 'id')));
 
-    INSERT INTO groups (name, slug, created_by, created_at, uuid)
-    VALUES ('Sith order group', 'sith-group', 1, now(), gen_random_uuid());
+    INSERT INTO groups (name, slug, created_by, created_at, uuid, org_id)
+    VALUES ('Sith order group', 'sith-group', 1, now(), gen_random_uuid(), 1);
     sith_order := (SELECT currval(pg_get_serial_sequence('groups', 'id')));
 
     INSERT INTO groups_users (group_id, user_id, created_at)


### PR DESCRIPTION
This pull request enhances the `GroupRepository` functionality by adding support for filtering groups by organization ID and updates the test and database initialization scripts accordingly. The changes include a new repository method, a corresponding test, and adjustments to the database schema.

### Repository Enhancements:
* Added a new method `findAllWithUsersAndProjects` in `GroupRepository` to support filtering groups by `organizationId`. This method uses an `@EntityGraph` to fetch associated users and projects for the groups.
* Imported `@Param` annotation in `GroupRepository` to support parameterized queries.

### Test Updates:
* Introduced a new test method `testFindAllWithUsersAndProjectsFilteredByOrgId` in `GroupRepositoryTest` to verify filtering functionality by organization ID.

### Database Schema Updates:
* Updated the `V001008__test_group_init.sql` script to include a new column `org_id` in the `groups` table, ensuring all test data includes an organization ID.