### PR TITLE
Add methods to find users by UUID and external ID in UserRepository

### DIFF
--- a/src/main/java/com/epam/ta/reportportal/dao/UserRepository.java
+++ b/src/main/java/com/epam/ta/reportportal/dao/UserRepository.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Modifying;
@@ -46,6 +47,18 @@ public interface UserRepository extends ReportPortalRepository<User, Long>, User
    * @return {@link Optional} of {@link User}
    */
   Optional<User> findByLogin(String login);
+
+  /**
+   * @param uuid user uuid for search
+   * @return {@link Optional} of {@link User}
+   */
+  Optional<User> findByUuid(UUID uuid);
+
+  /**
+   * @param externalId user external id for search
+   * @return {@link Optional} of {@link User}
+   */
+  Optional<User> findByExternalId(String externalId);
 
   List<User> findAllByEmailIn(Collection<String> mails);
 
@@ -84,5 +97,4 @@ public interface UserRepository extends ReportPortalRepository<User, Long>, User
 
   @Query(value = "SELECT users.login FROM users WHERE users.id = :id", nativeQuery = true)
   Optional<String> findLoginById(@Param("id") Long id);
-
 }

--- a/src/test/java/com/epam/ta/reportportal/dao/UserRepositoryTest.java
+++ b/src/test/java/com/epam/ta/reportportal/dao/UserRepositoryTest.java
@@ -203,6 +203,28 @@ class UserRepositoryTest extends BaseTest {
   }
 
   @Test
+  void findByUuid() {
+    final UUID uuid = userRepository.findByLogin("han_solo")
+        .map(User::getUuid)
+        .orElseThrow(() -> new IllegalStateException("User not found"));
+
+    Optional<User> user = userRepository.findByUuid(uuid);
+
+    assertTrue(user.isPresent(), "User not found");
+    assertThat("UUIDs are not equal", user.get().getUuid(), Matchers.equalTo(uuid));
+  }
+
+  @Test
+  void findByExternalId() {
+    final String externalId = "external_id_1";
+
+    Optional<User> user = userRepository.findByExternalId(externalId);
+
+    assertTrue(user.isPresent(), "User not found");
+    assertThat("External IDs are not equal", user.get().getExternalId(), Matchers.equalTo(externalId));
+  }
+
+  @Test
   void findAllByEmailIn() {
     List<String> emails = Arrays.asList("han_solo@domain.com", "chybaka@domain.com");
 

--- a/src/test/resources/db/migration/V001003__test_project_init.sql
+++ b/src/test/resources/db/migration/V001003__test_project_init.sql
@@ -25,10 +25,10 @@ BEGIN
     VALUES ('death_star', 'death_star', 'prj-death-star', now(), org_id);
     death_star := (SELECT currval(pg_get_serial_sequence('project', 'id')));
 
-    INSERT INTO users (login, password, email, role, type, full_name, expired, metadata, uuid)
+    INSERT INTO users (login, password, email, role, type, full_name, expired, metadata, uuid, external_id)
     VALUES ('han_solo', '3531f6f9b0538fd347f4c95bd2af9d01', 'han_solo@domain.com', 'ADMINISTRATOR',
             'INTERNAL', 'Han Solo', FALSE,
-            '{"metadata": {"last_login": "1551187023768"}}', gen_random_uuid());
+            '{"metadata": {"last_login": "1551187023768"}}', gen_random_uuid(), 'external_id_1');
     han_solo := (SELECT currval(pg_get_serial_sequence('users', 'id')));
 
     INSERT INTO project_user (user_id, project_id, project_role)


### PR DESCRIPTION
This pull request introduces enhancements to the `UserRepository` interface and its associated tests, as well as updates to the database schema. The changes add support for querying users by UUID and external ID, improve test coverage, and extend the database schema to include an `external_id` column in the `users` table.

### Enhancements to `UserRepository`:

* Added new methods `findByUuid(UUID uuid)` and `findByExternalId(String externalId)` to allow querying users by UUID and external ID.
* Updated imports in `UserRepository` to include `UUID`.

### Test coverage improvements:

* Added test cases `findByUuid()` and `findByExternalId()` in `UserRepositoryTest` to verify the functionality of the new query methods.

### Database schema updates:

* Modified the `users` table in `V001003__test_project_init.sql` to include a new `external_id` column, ensuring the schema supports the new query functionality.