### PR TITLE
EPMRPP-104894 || Add findEmailsByOrganization method to UserRepository

### DIFF
--- a/src/main/java/com/epam/ta/reportportal/dao/UserRepository.java
+++ b/src/main/java/com/epam/ta/reportportal/dao/UserRepository.java
@@ -88,6 +88,9 @@ public interface UserRepository extends ReportPortalRepository<User, Long>, User
   @Query(value = "SELECT u.email FROM users u JOIN project_user pu ON u.id = pu.user_id WHERE pu.project_id = :projectId", nativeQuery = true)
   List<String> findEmailsByProject(@Param("projectId") Long projectId);
 
+  @Query(value = "SELECT u.email FROM users u JOIN organization_user ou ON u.id = ou.user_id WHERE ou.organization_id = :organizationId", nativeQuery = true)
+  List<String> findEmailsByOrganization(@Param("organizationId") Long organizationId);
+
   @Query(value = "SELECT u.email FROM users u JOIN project_user pu ON u.id = pu.user_id WHERE pu.project_id = :projectId AND pu.project_role = cast(:#{#projectRole.name()} AS PROJECT_ROLE_ENUM)", nativeQuery = true)
   List<String> findEmailsByProjectAndRole(@Param("projectId") Long projectId,
       @Param("projectRole") ProjectRole projectRole);
@@ -97,4 +100,5 @@ public interface UserRepository extends ReportPortalRepository<User, Long>, User
 
   @Query(value = "SELECT users.login FROM users WHERE users.id = :id", nativeQuery = true)
   Optional<String> findLoginById(@Param("id") Long id);
+
 }

--- a/src/test/java/com/epam/ta/reportportal/dao/UserRepositoryTest.java
+++ b/src/test/java/com/epam/ta/reportportal/dao/UserRepositoryTest.java
@@ -442,6 +442,14 @@ class UserRepositoryTest extends BaseTest {
     assertEquals(1, emails.size());
   }
 
+  @Test
+  void findEmailsByOrganization() {
+    List<String> emails = userRepository.findEmailsByOrganization(1L);
+
+    assertFalse(emails.isEmpty());
+    assertEquals(2, emails.size());
+  }
+
 
   @Test
   void findProjectUsers() {


### PR DESCRIPTION
This pull request introduces a new query method to the `UserRepository` for retrieving user emails by organization and adds corresponding test coverage. The most important changes include the addition of the `findEmailsByOrganization` method and its integration into the test suite.

### Changes to `UserRepository`:

* Added the `findEmailsByOrganization` method to retrieve user emails based on organization ID using a native SQL query. (`src/main/java/com/epam/ta/reportportal/dao/UserRepository.java`, [src/main/java/com/epam/ta/reportportal/dao/UserRepository.javaR91-R93](diffhunk://#diff-f1b3f5b424dd98e732ebba1adf9e713dbf1635577cb452a9bf3548b98f276458R91-R93))

### Test coverage:

* Added a new test method `findEmailsByOrganization` in `UserRepositoryTest` to verify the functionality of the newly added query method. The test checks that the returned email list is not empty and matches the expected size. (`src/test/java/com/epam/ta/reportportal/dao/UserRepositoryTest.java`, [src/test/java/com/epam/ta/reportportal/dao/UserRepositoryTest.javaR445-R452](diffhunk://#diff-d95be9479348f9fa0a7d6d77028ed0ffa183ce27d666d8c0732393e810e3289dR445-R452))