### PR TITLE
Add UUID and external ID search methods to UserRepository

### DIFF
--- a/src/main/java/com/epam/ta/reportportal/dao/UserRepository.java
+++ b/src/main/java/com/epam/ta/reportportal/dao/UserRepository.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Modifying;
@@ -47,6 +48,18 @@ public interface UserRepository extends ReportPortalRepository<User, Long>, User
    */
   Optional<User> findByLogin(String login);
 
+  /**
+   * @param uuid user uuid for search
+   * @return {@link Optional} of {@link User}
+   */
+  Optional<User> findByUuid(UUID uuid);
+
+  /**
+   * @param externalId user external id for search
+   * @return {@link Optional} of {@link User}
+   */
+  Optional<User> findByExternalId(String externalId);
+
   List<User> findAllByEmailIn(Collection<String> mails);
 
   List<User> findAllByLoginIn(Set<String> loginSet);
@@ -63,7 +76,8 @@ public interface UserRepository extends ReportPortalRepository<User, Long>, User
 
   /**
    * Updates user's last login value
-   * @param username  User
+   *
+   * @param username User
    */
   @Modifying(clearAutomatically = true)
   @Query(value = "UPDATE users SET metadata = jsonb_set(metadata, '{metadata,last_login}', to_jsonb(round(extract(EPOCH from clock_timestamp()) * 1000)), TRUE ) WHERE login = :username", nativeQuery = true)

--- a/src/test/java/com/epam/ta/reportportal/dao/UserRepositoryTest.java
+++ b/src/test/java/com/epam/ta/reportportal/dao/UserRepositoryTest.java
@@ -197,6 +197,28 @@ class UserRepositoryTest extends BaseTest {
   }
 
   @Test
+  void findByUuid() {
+    final UUID uuid = userRepository.findByLogin("han_solo")
+        .map(User::getUuid)
+        .orElseThrow(() -> new IllegalStateException("User not found"));
+
+    Optional<User> user = userRepository.findByUuid(uuid);
+
+    assertTrue(user.isPresent(), "User not found");
+    assertThat("UUIDs are not equal", user.get().getUuid(), Matchers.equalTo(uuid));
+  }
+
+  @Test
+  void findByExternalId() {
+    final String externalId = "external_id_1";
+
+    Optional<User> user = userRepository.findByExternalId(externalId);
+
+    assertTrue(user.isPresent(), "User not found");
+    assertThat("External IDs are not equal", user.get().getExternalId(), Matchers.equalTo(externalId));
+  }
+
+  @Test
   void findAllByEmailIn() {
     List<String> emails = Arrays.asList("han_solo@domain.com", "chybaka@domain.com");
 

--- a/src/test/resources/db/migration/V001003__test_project_init.sql
+++ b/src/test/resources/db/migration/V001003__test_project_init.sql
@@ -19,10 +19,10 @@ BEGIN
     VALUES ('death_star', 'INTERNAL', now());
     death_star := (SELECT currval(pg_get_serial_sequence('project', 'id')));
 
-    INSERT INTO users (login, password, email, role, type, full_name, expired, metadata, uuid)
+    INSERT INTO users (login, password, email, role, type, full_name, expired, metadata, uuid, external_id)
     VALUES ('han_solo', '3531f6f9b0538fd347f4c95bd2af9d01', 'han_solo@domain.com', 'ADMINISTRATOR',
             'INTERNAL', 'Han Solo', FALSE,
-            '{"metadata": {"last_login": "1551187023768"}}', gen_random_uuid());
+            '{"metadata": {"last_login": "1551187023768"}}', gen_random_uuid(), 'external_id_1');
     han_solo := (SELECT currval(pg_get_serial_sequence('users', 'id')));
 
     INSERT INTO project_user (user_id, project_id, project_role)


### PR DESCRIPTION
This pull request adds new ways to look up users in the `UserRepository` by supporting queries using both UUID and external ID. It also updates the test data and test coverage to ensure these new repository methods work as expected.

**Repository enhancements:**

* Added `findByUuid(UUID uuid)` and `findByExternalId(String externalId)` methods to the `UserRepository` interface, allowing users to be queried by their UUID or external ID.

**Test coverage:**

* Added unit tests for the new `findByUuid` and `findByExternalId` methods in `UserRepositoryTest`, verifying correct lookup and matching of UUID and external ID.

**Test data updates:**

* Updated the test SQL migration (`V001003__test_project_init.sql`) to include an `external_id` for the `han_solo` user, ensuring test scenarios for external ID lookup are valid.

**Minor code improvements:**

* Added missing import for `UUID` in `UserRepository.java`.
* Improved JavaDoc formatting for the `updateLastLogin` method.