### PR TITLE
EPMRPP-106884 Fix organizations filter - add org_user_id

### DIFF
--- a/src/main/java/com/epam/ta/reportportal/commons/querygen/FilterTarget.java
+++ b/src/main/java/com/epam/ta/reportportal/commons/querygen/FilterTarget.java
@@ -1471,6 +1471,9 @@ public enum FilterTarget {
           .withAggregateCriteria("\"" + USERS_QUANTITY + "\"")
           .withIgnoreSelect(true)
           .get(),
+      new CriteriaHolderBuilder()
+          .newBuilder(CRITERIA_ORG_USER_ID, ORGANIZATION_USER.USER_ID, Long.class)
+          .get(),
       new CriteriaHolderBuilder().newBuilder(CRITERIA_ORG_PROJECTS, PROJECTS_QUANTITY, Long.class)
           .withAggregateCriteria("\"" + PROJECTS_QUANTITY + "\"")
           .withIgnoreSelect(true)

--- a/src/main/java/com/epam/ta/reportportal/commons/querygen/FilterTarget.java
+++ b/src/main/java/com/epam/ta/reportportal/commons/querygen/FilterTarget.java
@@ -1492,6 +1492,7 @@ public enum FilterTarget {
       SelectQuery<? extends Record> query = DSL.select(selectFields()).getQuery();
       addFrom(query);
       QuerySupplier querySupplier = new QuerySupplier(query);
+      joinTables(querySupplier);
       return querySupplier;
     }
 

--- a/src/main/java/com/epam/ta/reportportal/commons/querygen/FilterTarget.java
+++ b/src/main/java/com/epam/ta/reportportal/commons/querygen/FilterTarget.java
@@ -1544,6 +1544,9 @@ public enum FilterTarget {
 
     @Override
     protected void joinTables(QuerySupplier query) {
+        query.addJoin(ORGANIZATION_USER,
+                JoinType.LEFT_OUTER_JOIN,
+                ORGANIZATION_USER.ORGANIZATION_ID.eq(ORGANIZATION.ID));
     }
 
     @Override


### PR DESCRIPTION
This PR restores the org_user_id parameter in the criteria builder, which was removed in [PR #1134](https://github.com/reportportal/commons-dao/pull/1134). 
The missing filter caused an error: `Incorrect filtering parameters. Filter parameter org_user_id is not defined`