### PR TITLE
Feature/epmrpp 104711 organization plugin events

### DIFF
--- a/src/main/java/com/epam/ta/reportportal/entity/activity/ActivityAction.java
+++ b/src/main/java/com/epam/ta/reportportal/entity/activity/ActivityAction.java
@@ -73,6 +73,9 @@ public enum ActivityAction {
   DELETE_PROJECT("deleteProject"),
   BULK_DELETE_PROJECT("bulkDeleteProject"),
   UPDATE_PATTERN_ANALYZER("updatePatternAnalysisSettings"),
+  CREATE_ORGANIZATION("createOrganization"),
+  UPDATE_ORGANIZATION("updateOrganization"),
+  DELETE_ORGANIZATION("deleteOrganization"),
 
   UPDATE_INSTANCE("updateInstance");
 

--- a/src/main/java/com/epam/ta/reportportal/entity/activity/EventObject.java
+++ b/src/main/java/com/epam/ta/reportportal/entity/activity/EventObject.java
@@ -19,6 +19,7 @@ package com.epam.ta.reportportal.entity.activity;
 public enum EventObject {
 
   INSTANCE("instance"),
+  ORGANIZATION("organization"),
   LAUNCH("launch"),
   DASHBOARD("dashboard"),
   DEFECT_TYPE("defectType"),


### PR DESCRIPTION
This pull request introduces new support for organization-level activities in the activity tracking system. The main changes add new organization-related actions and event object types to the relevant enums, enabling the system to log and process organization events.

**Organization activity support:**

* Added new actions to the `ActivityAction` enum: `CREATE_ORGANIZATION`, `UPDATE_ORGANIZATION`, and `DELETE_ORGANIZATION`, allowing the system to track organization creation, updates, and deletions.
* Added `ORGANIZATION` to the `EventObject` enum to represent organization-related events in activity logs.