### PR TITLE
EPMRPP-105624 || Add method to fetch projects by organization ID

### DIFF
--- a/src/main/java/com/epam/ta/reportportal/dao/ProjectRepository.java
+++ b/src/main/java/com/epam/ta/reportportal/dao/ProjectRepository.java
@@ -40,6 +40,8 @@ public interface ProjectRepository extends ReportPortalRepository<Project, Long>
 
   Optional<Project> findByIdAndOrganizationId(Long projectId, Long organizationId);
 
+  List<Project> findAllByOrganizationId(Long organizationId);
+
   boolean existsByIdAndOrganizationId(Long projectId, Long organizationId);
 
   @Query(value = "SELECT p.* FROM project p JOIN project_user pu on p.id = pu.project_id JOIN users u on pu.user_id = u.id WHERE u.login = :login", nativeQuery = true)

--- a/src/test/java/com/epam/ta/reportportal/dao/ProjectRepositoryTest.java
+++ b/src/test/java/com/epam/ta/reportportal/dao/ProjectRepositoryTest.java
@@ -183,4 +183,32 @@ class ProjectRepositoryTest extends BaseTest {
     assertEquals(2, projectInfoPage.getTotalElements());
   }
 
+  @Test
+  void findAllByOrganizationId_WhenOrganizationExists_ShouldReturnAllProjectsForOrganization() {
+    // Given
+    Long organizationId = 1L;
+    
+    // When
+    List<Project> projects = projectRepository.findAllByOrganizationId(organizationId);
+    
+    // Then
+    assertEquals(2, projects.size());
+    assertEquals("superadmin_personal", projects.get(0).getName());
+    assertEquals("default_personal", projects.get(1).getName());
+    assertEquals(organizationId, projects.get(0).getOrganizationId());
+    assertEquals(organizationId, projects.get(1).getOrganizationId());
+  }
+
+  @Test
+  void findAllByOrganizationId_WhenOrganizationDoesNotExist_ShouldReturnEmptyList() {
+    // Given
+    Long nonExistentOrganizationId = 999L;
+    
+    // When
+    List<Project> projects = projectRepository.findAllByOrganizationId(nonExistentOrganizationId);
+    
+    // Then
+    assertTrue(projects.isEmpty());
+  }
+
 }


### PR DESCRIPTION
This PR introduces a Spring Data method to fetch all projects associated with a given organization id.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enables listing all projects associated with a selected organization, improving consistency when filtering or browsing projects by organization.
- Bug Fixes
  - Ensures empty results are returned when no projects exist for a specified organization, avoiding misleading displays.
- Tests
  - Added tests to validate accurate project retrieval by organization and correct empty-state handling, strengthening reliability of project listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->